### PR TITLE
Restart rápido da aplicação com DevTools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
### Extras

Reinício automático do Java Classloader Restart.

Caso não funcione, execute o procedimento a seguir:

**Mudanças na configuração de compilação do IntelliJ**
Vá para Settings -> Build, Execution, Deployment. -> Compiler
E habilite _build project automatically_

**Mudanças no registro do IntelliJ**
Vá para Cmd+Shift +A (Mac) or Ctrl+ Shift+A (Windows) -> Registry
E habilite _compiler.automake.allow.when.app.running_

Método alternativo:
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360003378800-How-to-configure-IDEA-for-Spring-Boot-DevTools

