### PR TITLE
Implementando endpoints de transição de status de pedido

### DIFF
--- a/src/main/java/com/course/springfood/api/controller/FluxoPedidoController.java
+++ b/src/main/java/com/course/springfood/api/controller/FluxoPedidoController.java
@@ -1,0 +1,33 @@
+package com.course.springfood.api.controller;
+
+import com.course.springfood.domain.service.FluxoPedidoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/pedidos/{pedidoId}")
+public class FluxoPedidoController {
+
+    @Autowired
+    private FluxoPedidoService fluxoPedido;
+
+    @PutMapping("/confirmacao")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void confirmar(@PathVariable Long pedidoId) {
+        fluxoPedido.confirmar(pedidoId);
+    }
+
+    @PutMapping("/cancelamento")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void cancelar(@PathVariable Long pedidoId) {
+        fluxoPedido.cancelar(pedidoId);
+    }
+
+    @PutMapping("/entrega")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void entregar(@PathVariable Long pedidoId) {
+        fluxoPedido.entregar(pedidoId);
+    }
+
+}

--- a/src/main/java/com/course/springfood/domain/model/StatusPedido.java
+++ b/src/main/java/com/course/springfood/domain/model/StatusPedido.java
@@ -2,8 +2,19 @@ package com.course.springfood.domain.model;
 
 public enum StatusPedido {
 
-    CRIADO,
-    CONFIRMADO,
-    ENTREGUE,
-    CANCELADO
+    CRIADO("Criado"),
+    CONFIRMADO("Confirmado"),
+    ENTREGUE("Entregue"),
+    CANCELADO("Cancelado");
+
+    private String descricao;
+
+    StatusPedido(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getDescricao() {
+        return this.descricao;
+    }
+
 }

--- a/src/main/java/com/course/springfood/domain/service/FluxoPedidoService.java
+++ b/src/main/java/com/course/springfood/domain/service/FluxoPedidoService.java
@@ -1,0 +1,63 @@
+package com.course.springfood.domain.service;
+
+import com.course.springfood.domain.exception.NegocioException;
+import com.course.springfood.domain.model.Pedido;
+import com.course.springfood.domain.model.StatusPedido;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+@Service
+public class FluxoPedidoService {
+
+    @Autowired
+    private EmissaoPedidoService emissaoPedido;
+
+    @Transactional
+    public void confirmar(Long pedidoId) {
+        Pedido pedido = emissaoPedido.buscarOuFalhar(pedidoId);
+
+        if (!pedido.getStatus().equals(StatusPedido.CRIADO)) {
+            throw new NegocioException(
+                    String.format("Status do pedido %d não pode ser alterado de %s para %s",
+                            pedido.getId(), pedido.getStatus().getDescricao(),
+                            StatusPedido.CONFIRMADO.getDescricao()));
+        }
+
+        pedido.setStatus(StatusPedido.CONFIRMADO);
+        pedido.setDataConfirmacao(OffsetDateTime.now());
+    }
+
+    @Transactional
+    public void cancelar(Long pedidoId) {
+        Pedido pedido = emissaoPedido.buscarOuFalhar(pedidoId);
+
+        if (!pedido.getStatus().equals(StatusPedido.CRIADO)) {
+            throw new NegocioException(
+                    String.format("Status do pedido %d não pode ser alterado de %s para %s",
+                            pedido.getId(), pedido.getStatus().getDescricao(),
+                            StatusPedido.CANCELADO.getDescricao()));
+        }
+
+        pedido.setStatus(StatusPedido.CANCELADO);
+        pedido.setDataCancelamento(OffsetDateTime.now());
+    }
+
+    @Transactional
+    public void entregar(Long pedidoId) {
+        Pedido pedido = emissaoPedido.buscarOuFalhar(pedidoId);
+
+        if (!pedido.getStatus().equals(StatusPedido.CONFIRMADO)) {
+            throw new NegocioException(
+                    String.format("Status do pedido %d não pode ser alterado de %s para %s",
+                            pedido.getId(), pedido.getStatus().getDescricao(),
+                            StatusPedido.ENTREGUE.getDescricao()));
+        }
+
+        pedido.setStatus(StatusPedido.ENTREGUE);
+        pedido.setDataEntrega(OffsetDateTime.now());
+    }
+
+}


### PR DESCRIPTION
Adicionado:
- Endpoint para status de pedido: CONFIRMADO (confirmação que recebeu o pedido)
- Endpoint para status de pedido: CANCELADO
- Endpoint para status de pedido: ENTREGUE

Obs:
Existem algumas regras:
- O Status CONFIRMADO só pode ser gerado a partir do status CRIADO
- O Status CANCELADO só pode ser gerado a partir do status CRIADO
- O Status ENTREGUE só pode ser gerado a partir do status CONFIRMADO