### PR TITLE
Selecionando a implementação do serviço de storage de fotos

### DIFF
--- a/src/main/java/com/course/springfood/core/storage/StorageConfig.java
+++ b/src/main/java/com/course/springfood/core/storage/StorageConfig.java
@@ -4,17 +4,23 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.course.springfood.core.storage.StorageProperties.TipoStorage;
+import com.course.springfood.domain.service.FotoStorageService;
+import com.course.springfood.infrastructure.service.storage.LocalFotoStorageService;
+import com.course.springfood.infrastructure.service.storage.S3FotoStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AmazonS3Config {
+public class StorageConfig {
 
     @Autowired
     private StorageProperties storageProperties;
 
     @Bean
+    @ConditionalOnProperty(name = "springfood.storage.tipo", havingValue = "s3")
     public AmazonS3 amazonS3() {
         var credentials = new BasicAWSCredentials(
                 storageProperties.getS3().getIdChaveAcesso(),
@@ -24,6 +30,15 @@ public class AmazonS3Config {
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(storageProperties.getS3().getRegiao())
                 .build();
+    }
+
+    @Bean
+    public FotoStorageService fotoStorageService() {
+        if (TipoStorage.S3.equals(storageProperties.getTipo())) {
+            return new S3FotoStorageService();
+        } else {
+            return new LocalFotoStorageService();
+        }
     }
 
 }

--- a/src/main/java/com/course/springfood/core/storage/StorageProperties.java
+++ b/src/main/java/com/course/springfood/core/storage/StorageProperties.java
@@ -16,6 +16,13 @@ public class StorageProperties {
 
     private Local local = new Local();
     private S3 s3 = new S3();
+    private TipoStorage tipo = TipoStorage.LOCAL;
+
+    public enum TipoStorage {
+
+        LOCAL, S3
+
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/course/springfood/infrastructure/service/storage/S3FotoStorageService.java
+++ b/src/main/java/com/course/springfood/infrastructure/service/storage/S3FotoStorageService.java
@@ -8,11 +8,9 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.course.springfood.core.storage.StorageProperties;
 import com.course.springfood.domain.service.FotoStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.net.URL;
 
-@Service
 public class S3FotoStorageService implements FotoStorageService {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,10 +16,12 @@ spring.resources.add-mappings=false
 #spring.servlet.multipart.max-file-size=20KB
 #spring.servlet.multipart.max-request-size=20MB
 
+springfood.storage.tipo=local
+
 springfood.storage.local.diretorio-fotos=/home/xxx/Documentos
 
-springfood.storage.s3.id-chave-acesso=TeStEaMaZoNs3
-springfood.storage.s3.chave-acesso-secreta=tEsTeAmAzOnS3
+#springfood.storage.s3.id-chave-acesso=
+#springfood.storage.s3.chave-acesso-secreta=
 springfood.storage.s3.bucket=springfood-bckt
 springfood.storage.s3.regiao=us-east-1
 springfood.storage.s3.diretorio-fotos=catalogo


### PR DESCRIPTION
Criando opção de escolha qual configuração por meio de um parâmetro chamado "springfood.storage.tipo" no "application.properties".

Antes da implementação, a definição de qual serviço (Local ou S3) seria utilizado, era necessário comentar a anotação @Service da classe que não seria o Bean responsável pelo armazemento (LocalFotoStorageService ou S3FotoStorageService).