### PR TITLE
Implementando envio de e-mails transacionais com SendGrid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,14 @@
 			<artifactId>aws-java-sdk-s3</artifactId>
 			<version>${aws-java-sdk-s3.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-freemarker</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/course/springfood/core/email/EmailConfig.java
+++ b/src/main/java/com/course/springfood/core/email/EmailConfig.java
@@ -1,0 +1,31 @@
+package com.course.springfood.core.email;
+
+import com.course.springfood.domain.service.EnvioEmailService;
+import com.course.springfood.infrastructure.service.email.FakeEnvioEmailService;
+import com.course.springfood.infrastructure.service.email.SandboxEnvioEmailService;
+import com.course.springfood.infrastructure.service.email.SmtpEnvioEmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmailConfig {
+
+    @Autowired
+    private EmailProperties emailProperties;
+
+    @Bean
+    public EnvioEmailService envioEmailService() {
+        switch (emailProperties.getImpl()) {
+            case FAKE:
+                return new FakeEnvioEmailService();
+            case SMTP:
+                return new SmtpEnvioEmailService();
+            case SANDBOX:
+                return new SandboxEnvioEmailService();
+            default:
+                return null;
+        }
+    }
+
+}

--- a/src/main/java/com/course/springfood/core/email/EmailProperties.java
+++ b/src/main/java/com/course/springfood/core/email/EmailProperties.java
@@ -1,0 +1,37 @@
+package com.course.springfood.core.email;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+
+@Validated
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("springfood.email")
+public class EmailProperties {
+
+    private Implementacao impl = Implementacao.FAKE;
+
+    @NotNull
+    private String remetente;
+
+    private Sandbox sandbox = new Sandbox();
+
+    public enum Implementacao {
+        SMTP, FAKE, SANDBOX
+    }
+
+    @Getter
+    @Setter
+    public class Sandbox {
+
+        private String destinatario;
+
+    }
+
+}

--- a/src/main/java/com/course/springfood/domain/service/EnvioEmailService.java
+++ b/src/main/java/com/course/springfood/domain/service/EnvioEmailService.java
@@ -1,0 +1,33 @@
+package com.course.springfood.domain.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Singular;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface EnvioEmailService {
+
+    void enviar(Mensagem mensagem);
+
+    @Getter
+    @Builder
+    class Mensagem {
+
+        @Singular
+        private Set<String> destinatarios;
+
+        @NonNull
+        private String assunto;
+
+        @NonNull
+        private String corpo;
+
+        @Singular("variavel")
+        private Map<String, Object> variaveis;
+
+    }
+
+}

--- a/src/main/java/com/course/springfood/domain/service/FluxoPedidoService.java
+++ b/src/main/java/com/course/springfood/domain/service/FluxoPedidoService.java
@@ -1,6 +1,7 @@
 package com.course.springfood.domain.service;
 
 import com.course.springfood.domain.model.Pedido;
+import com.course.springfood.domain.service.EnvioEmailService.Mensagem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,10 +12,22 @@ public class FluxoPedidoService {
     @Autowired
     private EmissaoPedidoService emissaoPedido;
 
+    @Autowired
+    private EnvioEmailService envioEmail;
+
     @Transactional
     public void confirmar(String codigoPedido) {
         Pedido pedido = emissaoPedido.buscarOuFalhar(codigoPedido);
         pedido.confirmar();
+
+        var mensagem = Mensagem.builder()
+                .assunto(pedido.getRestaurante().getNome() + " - Pedido confirmado")
+                .corpo("pedido-confirmado.html")
+                .variavel("pedido", pedido)
+                .destinatario(pedido.getCliente().getEmail())
+                .build();
+
+        envioEmail.enviar(mensagem);
     }
 
     @Transactional

--- a/src/main/java/com/course/springfood/infrastructure/service/email/EmailException.java
+++ b/src/main/java/com/course/springfood/infrastructure/service/email/EmailException.java
@@ -1,0 +1,15 @@
+package com.course.springfood.infrastructure.service.email;
+
+public class EmailException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/course/springfood/infrastructure/service/email/FakeEnvioEmailService.java
+++ b/src/main/java/com/course/springfood/infrastructure/service/email/FakeEnvioEmailService.java
@@ -1,0 +1,15 @@
+package com.course.springfood.infrastructure.service.email;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FakeEnvioEmailService extends SmtpEnvioEmailService {
+
+    @Override
+    public void enviar(Mensagem mensagem) {
+        String corpo = processarTemplate(mensagem);
+
+        log.info("[FAKE E-MAIL] Para: {}\n{}", mensagem.getDestinatarios(), corpo);
+    }
+
+}

--- a/src/main/java/com/course/springfood/infrastructure/service/email/SandboxEnvioEmailService.java
+++ b/src/main/java/com/course/springfood/infrastructure/service/email/SandboxEnvioEmailService.java
@@ -1,0 +1,27 @@
+package com.course.springfood.infrastructure.service.email;
+
+import com.course.springfood.core.email.EmailProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+public class SandboxEnvioEmailService extends SmtpEnvioEmailService {
+
+    @Autowired
+    private EmailProperties emailProperties;
+
+    // Separei a criação de MimeMessage em um método na classe pai (criarMimeMessage),
+    // para possibilitar a sobrescrita desse método aqui
+    @Override
+    protected MimeMessage criarMimeMessage(Mensagem mensagem) throws MessagingException {
+        MimeMessage mimeMessage = super.criarMimeMessage(mensagem);
+
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+        helper.setTo(emailProperties.getSandbox().getDestinatario());
+
+        return mimeMessage;
+    }
+
+}

--- a/src/main/java/com/course/springfood/infrastructure/service/email/SmtpEnvioEmailService.java
+++ b/src/main/java/com/course/springfood/infrastructure/service/email/SmtpEnvioEmailService.java
@@ -1,0 +1,62 @@
+package com.course.springfood.infrastructure.service.email;
+
+import com.course.springfood.core.email.EmailProperties;
+import com.course.springfood.domain.service.EnvioEmailService;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+public class SmtpEnvioEmailService implements EnvioEmailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Autowired
+    private EmailProperties emailProperties;
+
+    @Autowired
+    private Configuration freemarkerConfig;
+
+    @Override
+    public void enviar(Mensagem mensagem) {
+        try {
+            MimeMessage mimeMessage = criarMimeMessage(mensagem);
+
+            mailSender.send(mimeMessage);
+        } catch (Exception e) {
+            throw new EmailException("Não foi possível enviar e-mail", e);
+        }
+    }
+
+    protected MimeMessage criarMimeMessage(Mensagem mensagem) throws MessagingException {
+        String corpo = processarTemplate(mensagem);
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+        helper.setFrom(emailProperties.getRemetente());
+        helper.setTo(mensagem.getDestinatarios().toArray(new String[0]));
+        helper.setSubject(mensagem.getAssunto());
+        helper.setText(corpo, true);
+
+        return mimeMessage;
+    }
+
+    protected String processarTemplate(Mensagem mensagem) {
+        try {
+            Template template = freemarkerConfig.getTemplate(mensagem.getCorpo());
+
+            return FreeMarkerTemplateUtils.processTemplateIntoString(
+                    template, mensagem.getVariaveis());
+        } catch (Exception e) {
+            throw new EmailException("Não foi possível montar o template do e-mail", e);
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,12 @@ springfood.storage.local.diretorio-fotos=/home/xxx/Documentos
 springfood.storage.s3.bucket=springfood-bckt
 springfood.storage.s3.regiao=us-east-1
 springfood.storage.s3.diretorio-fotos=catalogo
+
+spring.mail.host=smtp.sendgrid.net
+spring.mail.port=587
+spring.mail.username=apikey
+#spring.mail.password=API_KEY_GERADA_NA_CRIACAO_DA CONTA_SENDGRID
+spring.freemarker.settings.locale=pt_BR
+springfood.email.impl=sandbox
+springfood.email.remetente=SpringFood <enviar@springfood.com>
+springfood.email.sandbox.destinatario=receber@springfood.com

--- a/src/main/resources/templates/pedido-confirmado.html
+++ b/src/main/resources/templates/pedido-confirmado.html
@@ -1,0 +1,32 @@
+<html>
+<body style="font: 14px Arial, Helvetica, sans-serif">
+<h1 style="color: red; font-size: 26px">Pedido confirmado!</h1>
+
+<p>${pedido.cliente.nome}, seu pedido foi confirmado pelo restaurante e já
+    está sendo preparado.</p>
+
+<h2 style="font-size: 20px">${pedido.restaurante.nome}</h2>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0"
+       style="max-width: 400px; color: #6F6F6F">
+    <#list pedido.itens as item>
+    <tr>
+        <td style="padding: 10px 0">${item.quantidade}x ${item.produto.nome}</td>
+        <td style="width: 30px">${item.precoTotal?string.currency}</td>
+    </tr>
+</#list>
+
+<tr>
+    <td style="padding: 10px 0">Frete</td>
+    <td>${pedido.taxaFrete?string.currency}</td>
+</tr>
+<tr style="font-weight: bold">
+    <td style="padding: 10px 0">Total</td>
+    <td>${pedido.valorTotal?string.currency}</td>
+</tr>
+</table>
+
+<h2 style="font-size: 20px">Forma de pagamento</h2>
+<p style="color: #6F6F6F">${pedido.formaPagamento.descricao}</p>
+</body>
+</html>


### PR DESCRIPTION
Implementação de envio de e-mail (utilizando o SendGrid) com a confirmação do pedido.
Quando o endpoint "http://localhost:8080/pedidos/COD_PEDIDO/confirmacao" é executado para confirmar um pedido, um e-mail é disparado para o responsável do pedido.
