### PR TITLE
Autenticação - Spring Security com HTTP Basic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,15 @@
 			<artifactId>logback-ext-loggly</artifactId>
 			<version>${logback-ext-loggly.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/course/springfood/core/security/WebSecurityConfig.java
+++ b/src/main/java/com/course/springfood/core/security/WebSecurityConfig.java
@@ -1,0 +1,52 @@
+package com.course.springfood.core.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.inMemoryAuthentication()
+                .withUser("djalma")
+                .password(passwordEncoder().encode("123"))
+                .roles("ADMIN")
+                .and()
+                .withUser("jose")
+                .password(passwordEncoder().encode("123"))
+                .roles("ADMIN");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .httpBasic()
+
+                .and()
+                .authorizeRequests()
+                .antMatchers("/v1/cozinhas/**").permitAll()
+                .anyRequest().authenticated()
+
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                .and()
+                .csrf().disable();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,7 @@ spring.freemarker.settings.locale=pt_BR
 springfood.email.impl=sandbox
 springfood.email.remetente=SpringFood <enviar@springfood.com>
 springfood.email.sandbox.destinatario=receber@springfood.com
+
+# login
+#spring.security.user.name=USUARIO_NOME
+#spring.security.user.password=USUARIO_SENHA


### PR DESCRIPTION
Quando a biblioteca do Spring Security é adicionada, automaticamente a segurança é implementada.

Durante o processo de inicialização da aplicação, um token (aleatório) é exibido no console:

`Using generated security password: 60da4977-d16e-42b8-b736-a8254f6036ee`

Esse token corresponde ao usuário padrão, que caso não tenha sido configurado se chama "user".

Nesse momento, para qualquer requisição, é necessário informar um header de key "Authorization" com o value contendo o prefixo "Basic " e a combinação "user:TOKEN_GERADO" convertido em base64.
Ex: Para o Token "60da4977-d16e-42b8-b736-a8254f6036ee" será necessário converter a string: "user:60da4977-d16e-42b8-b736-a8254f6036ee", tendo como resultado: "dXNlcjo2MGRhNDk3Ny1kMTZlLTQyYjgtYjczNi1hODI1NGY2MDM2ZWU=". 
Com isso é necessário informar um header de key "**Authorization**" com o value "**Basic dXNlcjo2MGRhNDk3Ny1kMTZlLTQyYjgtYjczNi1hODI1NGY2MDM2ZWU=**".

Obs: Ao invés de converter a string "user:TOKEN_GERADO" em base64, é possível ativar a autenticação do tipo Básica (Basic Auth), como no Postman, informando "user" como Username e o "token" como Password.


Para criar um usuário (sem ter que utilizar o padrão "user" com o token aleatório) é possível informar as seguintes configurações no "application.properties":

```
spring.security.user.name=springfood
spring.security.user.password=123456
```

Obs: Mesmo assim é necessário realizar o procedimento anterior, convertendo para base64 ou informá-los nos campos de autenticação.