### PR TITLE
Configurando para receber JWT assinado com chave simétrica

### DIFF
--- a/src/main/java/com/course/springfood/core/security/ResourceServerConfig.java
+++ b/src/main/java/com/course/springfood/core/security/ResourceServerConfig.java
@@ -1,9 +1,14 @@
 package com.course.springfood.core.security;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import javax.crypto.spec.SecretKeySpec;
 
 @Configuration
 @EnableWebSecurity
@@ -12,12 +17,18 @@ public class ResourceServerConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()  //Desativado CSRF
                 .authorizeRequests()
                 .anyRequest().authenticated()
                 .and()
                 .cors().and()
-                .oauth2ResourceServer().opaqueToken();
+                .oauth2ResourceServer().jwt();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        var secretKey = new SecretKeySpec("YXV0aG9yaXphdGlvbmRqYWxtYXNwcmluZ2Zvb2Q".getBytes(), "HmacSHA256");
+
+        return NimbusJwtDecoder.withSecretKey(secretKey).build();
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,11 +20,7 @@ server.compression.enabled=true
 #server.compression.min-response-size=true
 
 #logging.loggly.token=LOGGLY_CUSTOMER_TOKEN
-
-# Authorization Server
-spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=http://localhost:8081/oauth/check_token
-spring.security.oauth2.resourceserver.opaquetoken.client-id=checktoken
-spring.security.oauth2.resourceserver.opaquetoken.client-secret=check123
+#logging.level.org.springframework=DEBUG
 
 # Storage
 springfood.storage.tipo=local


### PR DESCRIPTION
Para utilizar o JWT é necessário que a "secret" tenha **256 bits** (32 bytes).

Obs: geralmente caracteres normais tem 1 byte e caracteres especiais 2 bytes.

Obs 2: utilizei o site "https://base64.guru/standards/base64url/encode" para converter a palavra "authorizationdjalmaspringfood" para base64url e utilizar como secret.

Obs 3: para desconverter base64url para string: "https://base64.guru/standards/base64url/decode".