### PR TITLE
Carregando Granted Authorities e restringindo acesso a endpoints por escopos do OAuth2

### DIFF
--- a/src/main/java/com/course/springfood/core/security/CheckSecurity.java
+++ b/src/main/java/com/course/springfood/core/security/CheckSecurity.java
@@ -12,12 +12,12 @@ public @interface CheckSecurity {
 
     public @interface Cozinhas {
 
-        @PreAuthorize("hasAuthority('EDITAR_COZINHAS')")
+        @PreAuthorize("hasAuthority('SCOPE_WRITE') and hasAuthority('EDITAR_COZINHAS')")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeEditar { }
 
-        @PreAuthorize("isAuthenticated()")
+        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }

--- a/src/main/java/com/course/springfood/core/security/ResourceServerConfig.java
+++ b/src/main/java/com/course/springfood/core/security/ResourceServerConfig.java
@@ -5,9 +5,12 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -34,9 +37,14 @@ public class ResourceServerConfig extends WebSecurityConfigurerAdapter {
                 authorities = Collections.emptyList();
             }
 
-            return authorities.stream()
+            var scopesAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+            Collection<GrantedAuthority> grantedAuthorities = scopesAuthoritiesConverter.convert(jwt);
+
+            grantedAuthorities.addAll(authorities.stream()
                     .map(SimpleGrantedAuthority::new)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toList()));
+
+            return grantedAuthorities;
         });
 
         return jwtAuthenticationConverter;


### PR DESCRIPTION
- Carregando Granted Authorities dos escopos do OAuth2 
- Restringindo acesso a endpoints por escopos do OAuth2

Obs: Foi necessário adicionar os scopos recebidos no token como Granted Authorities para utilizá-los como regra de acesso juntamente com as permissões de usuários.