### PR TITLE
Gerando links do HAL dinamicamente de acordo com permissões do usuário

### DIFF
--- a/src/main/java/com/course/springfood/api/v1/assembler/CidadeModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/CidadeModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.CidadeController;
 import com.course.springfood.api.v1.model.CidadeModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Cidade;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class CidadeModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public CidadeModelAssembler() {
         super(CidadeController.class, CidadeModel.class);
     }
@@ -30,17 +34,26 @@ public class CidadeModelAssembler
 
         modelMapper.map(cidade, cidadeModel);
 
-        cidadeModel.add(springLinks.linkToCidades("cidades"));
+        if (springSecurity.podeConsultarCidades()) {
+            cidadeModel.add(springLinks.linkToCidades("cidades"));
+        }
 
-        cidadeModel.getEstado().add(springLinks.linkToEstado(cidadeModel.getEstado().getId()));
+        if (springSecurity.podeConsultarEstados()) {
+            cidadeModel.getEstado().add(springLinks.linkToEstado(cidadeModel.getEstado().getId()));
+        }
 
         return cidadeModel;
     }
 
     @Override
     public CollectionModel<CidadeModel> toCollectionModel(Iterable<? extends Cidade> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToCidades());
+        CollectionModel<CidadeModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarCidades()) {
+            collectionModel.add(springLinks.linkToCidades());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/CozinhaModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/CozinhaModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.CozinhaController;
 import com.course.springfood.api.v1.model.CozinhaModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Cozinha;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class CozinhaModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public CozinhaModelAssembler() {
         super(CozinhaController.class, CozinhaModel.class);
     }
@@ -28,7 +32,9 @@ public class CozinhaModelAssembler
         CozinhaModel cozinhaModel = createModelWithId(cozinha.getId(), cozinha);
         modelMapper.map(cozinha, cozinhaModel);
 
-        cozinhaModel.add(springLinks.linkToCozinhas("cozinhas"));
+        if (springSecurity.podeConsultarCozinhas()) {
+            cozinhaModel.add(springLinks.linkToCozinhas("cozinhas"));
+        }
 
         return cozinhaModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/assembler/EstadoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/EstadoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.EstadoController;
 import com.course.springfood.api.v1.model.EstadoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Estado;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class EstadoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public EstadoModelAssembler() {
         super(EstadoController.class, EstadoModel.class);
     }
@@ -29,15 +33,22 @@ public class EstadoModelAssembler
         EstadoModel estadoModel = createModelWithId(estado.getId(), estado);
         modelMapper.map(estado, estadoModel);
 
-        estadoModel.add(springLinks.linkToEstados("estados"));
+        if (springSecurity.podeConsultarEstados()) {
+            estadoModel.add(springLinks.linkToEstados("estados"));
+        }
 
         return estadoModel;
     }
 
     @Override
     public CollectionModel<EstadoModel> toCollectionModel(Iterable<? extends Estado> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToEstados());
+        CollectionModel<EstadoModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarEstados()) {
+            collectionModel.add(springLinks.linkToEstados());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/FormaPagamentoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/FormaPagamentoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.FormaPagamentoController;
 import com.course.springfood.api.v1.model.FormaPagamentoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.FormaPagamento;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class FormaPagamentoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public FormaPagamentoModelAssembler() {
         super(FormaPagamentoController.class, FormaPagamentoModel.class);
     }
@@ -31,15 +35,22 @@ public class FormaPagamentoModelAssembler
 
         modelMapper.map(formaPagamento, formaPagamentoModel);
 
-        formaPagamentoModel.add(springLinks.linkToFormasPagamento("formasPagamento"));
+        if (springSecurity.podeConsultarFormasPagamento()) {
+            formaPagamentoModel.add(springLinks.linkToFormasPagamento("formasPagamento"));
+        }
 
         return formaPagamentoModel;
     }
 
     @Override
     public CollectionModel<FormaPagamentoModel> toCollectionModel(Iterable<? extends FormaPagamento> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToFormasPagamento());
+        CollectionModel<FormaPagamentoModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarFormasPagamento()) {
+            collectionModel.add(springLinks.linkToFormasPagamento());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/FotoProdutoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/FotoProdutoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.RestauranteProdutoFotoController;
 import com.course.springfood.api.v1.model.FotoProdutoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.FotoProduto;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class FotoProdutoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public FotoProdutoModelAssembler() {
         super(RestauranteProdutoFotoController.class, FotoProdutoModel.class);
     }
@@ -27,11 +31,14 @@ public class FotoProdutoModelAssembler
     public FotoProdutoModel toModel(FotoProduto foto) {
         FotoProdutoModel fotoProdutoModel = modelMapper.map(foto, FotoProdutoModel.class);
 
-        fotoProdutoModel.add(springLinks.linkToFotoProduto(
-                foto.getRestauranteId(), foto.getProduto().getId()));
+        // Quem pode consultar restaurantes, também pode consultar os produtos e fotos
+        if (springSecurity.podeConsultarRestaurantes()) {
+            fotoProdutoModel.add(springLinks.linkToFotoProduto(
+                    foto.getRestauranteId(), foto.getProduto().getId()));
 
-        fotoProdutoModel.add(springLinks.linkToProduto(
-                foto.getRestauranteId(), foto.getProduto().getId(), "produto"));
+            fotoProdutoModel.add(springLinks.linkToProduto(
+                    foto.getRestauranteId(), foto.getProduto().getId(), "produto"));
+        }
 
         return fotoProdutoModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/assembler/GrupoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/GrupoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.GrupoController;
 import com.course.springfood.api.v1.model.GrupoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Grupo;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class GrupoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public GrupoModelAssembler() {
         super(GrupoController.class, GrupoModel.class);
     }
@@ -29,17 +33,24 @@ public class GrupoModelAssembler
         GrupoModel grupoModel = createModelWithId(grupo.getId(), grupo);
         modelMapper.map(grupo, grupoModel);
 
-        grupoModel.add(springLinks.linkToGrupos("grupos"));
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            grupoModel.add(springLinks.linkToGrupos("grupos"));
 
-        grupoModel.add(springLinks.linkToGrupoPermissoes(grupo.getId(), "permissoes"));
+            grupoModel.add(springLinks.linkToGrupoPermissoes(grupo.getId(), "permissoes"));
+        }
 
         return grupoModel;
     }
 
     @Override
     public CollectionModel<GrupoModel> toCollectionModel(Iterable<? extends Grupo> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToGrupos());
+        CollectionModel<GrupoModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            collectionModel.add(springLinks.linkToGrupos());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/PedidoResumoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/PedidoResumoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.PedidoController;
 import com.course.springfood.api.v1.model.PedidoResumoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Pedido;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class PedidoResumoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public PedidoResumoModelAssembler() {
         super(PedidoController.class, PedidoResumoModel.class);
     }
@@ -28,12 +32,18 @@ public class PedidoResumoModelAssembler
         PedidoResumoModel pedidoModel = createModelWithId(pedido.getCodigo(), pedido);
         modelMapper.map(pedido, pedidoModel);
 
-        pedidoModel.add(springLinks.linkToPedidos("pedidos"));
+        if (springSecurity.podePesquisarPedidos()) {
+            pedidoModel.add(springLinks.linkToPedidos("pedidos"));
+        }
 
-        pedidoModel.getRestaurante().add(
-                springLinks.linkToRestaurante(pedido.getRestaurante().getId()));
+        if (springSecurity.podeConsultarRestaurantes()) {
+            pedidoModel.getRestaurante().add(
+                    springLinks.linkToRestaurante(pedido.getRestaurante().getId()));
+        }
 
-        pedidoModel.getCliente().add(springLinks.linkToUsuario(pedido.getCliente().getId()));
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            pedidoModel.getCliente().add(springLinks.linkToUsuario(pedido.getCliente().getId()));
+        }
 
         return pedidoModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/assembler/PermissaoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/PermissaoModelAssembler.java
@@ -2,6 +2,7 @@ package com.course.springfood.api.v1.assembler;
 
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.model.PermissaoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Permissao;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class PermissaoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @Override
     public PermissaoModel toModel(Permissao permissao) {
         PermissaoModel permissaoModel = modelMapper.map(permissao, PermissaoModel.class);
@@ -27,8 +31,14 @@ public class PermissaoModelAssembler
 
     @Override
     public CollectionModel<PermissaoModel> toCollectionModel(Iterable<? extends Permissao> entities) {
-        return RepresentationModelAssembler.super.toCollectionModel(entities)
-                .add(springLinks.linkToPermissoes());
+        CollectionModel<PermissaoModel> collectionModel
+                = RepresentationModelAssembler.super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            collectionModel.add(springLinks.linkToPermissoes());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/ProdutoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/ProdutoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.RestauranteProdutoController;
 import com.course.springfood.api.v1.model.ProdutoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Produto;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ public class ProdutoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public ProdutoModelAssembler() {
         super(RestauranteProdutoController.class, ProdutoModel.class);
     }
@@ -30,10 +34,13 @@ public class ProdutoModelAssembler
 
         modelMapper.map(produto, produtoModel);
 
-        produtoModel.add(springLinks.linkToProdutos(produto.getRestaurante().getId(), "produtos"));
+        // Quem pode consultar restaurantes, também pode consultar os produtos e fotos
+        if (springSecurity.podeConsultarRestaurantes()) {
+            produtoModel.add(springLinks.linkToProdutos(produto.getRestaurante().getId(), "produtos"));
 
-        produtoModel.add(springLinks.linkToFotoProduto(
-                produto.getRestaurante().getId(), produto.getId(), "foto"));
+            produtoModel.add(springLinks.linkToFotoProduto(
+                    produto.getRestaurante().getId(), produto.getId(), "foto"));
+        }
 
         return produtoModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/assembler/RestauranteApenasNomeModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/RestauranteApenasNomeModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.RestauranteController;
 import com.course.springfood.api.v1.model.RestauranteApenasNomeModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Restaurante;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class RestauranteApenasNomeModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public RestauranteApenasNomeModelAssembler() {
         super(RestauranteController.class, RestauranteApenasNomeModel.class);
     }
@@ -31,15 +35,22 @@ public class RestauranteApenasNomeModelAssembler
 
         modelMapper.map(restaurante, restauranteModel);
 
-        restauranteModel.add(springLinks.linkToRestaurantes("restaurantes"));
+        if (springSecurity.podeConsultarRestaurantes()) {
+            restauranteModel.add(springLinks.linkToRestaurantes("restaurantes"));
+        }
 
         return restauranteModel;
     }
 
     @Override
     public CollectionModel<RestauranteApenasNomeModel> toCollectionModel(Iterable<? extends Restaurante> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToRestaurantes());
+        CollectionModel<RestauranteApenasNomeModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarRestaurantes()) {
+            collectionModel.add(springLinks.linkToRestaurantes());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/RestauranteBasicoModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/RestauranteBasicoModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.RestauranteController;
 import com.course.springfood.api.v1.model.RestauranteBasicoModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Restaurante;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class RestauranteBasicoModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public RestauranteBasicoModelAssembler() {
         super(RestauranteController.class, RestauranteBasicoModel.class);
     }
@@ -31,18 +35,27 @@ public class RestauranteBasicoModelAssembler
 
         modelMapper.map(restaurante, restauranteModel);
 
-        restauranteModel.add(springLinks.linkToRestaurantes("restaurantes"));
+        if (springSecurity.podeConsultarRestaurantes()) {
+            restauranteModel.add(springLinks.linkToRestaurantes("restaurantes"));
+        }
 
-        restauranteModel.getCozinha().add(
-                springLinks.linkToCozinha(restaurante.getCozinha().getId()));
+        if (springSecurity.podeConsultarCozinhas()) {
+            restauranteModel.getCozinha().add(
+                    springLinks.linkToCozinha(restaurante.getCozinha().getId()));
+        }
 
         return restauranteModel;
     }
 
     @Override
     public CollectionModel<RestauranteBasicoModel> toCollectionModel(Iterable<? extends Restaurante> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToRestaurantes());
+        CollectionModel<RestauranteBasicoModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarRestaurantes()) {
+            collectionModel.add(springLinks.linkToRestaurantes());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/assembler/UsuarioModelAssembler.java
+++ b/src/main/java/com/course/springfood/api/v1/assembler/UsuarioModelAssembler.java
@@ -3,6 +3,7 @@ package com.course.springfood.api.v1.assembler;
 import com.course.springfood.api.v1.SpringLinks;
 import com.course.springfood.api.v1.controller.UsuarioController;
 import com.course.springfood.api.v1.model.UsuarioModel;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Usuario;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,9 @@ public class UsuarioModelAssembler
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     public UsuarioModelAssembler() {
         super(UsuarioController.class, UsuarioModel.class);
     }
@@ -29,17 +33,24 @@ public class UsuarioModelAssembler
         UsuarioModel usuarioModel = createModelWithId(usuario.getId(), usuario);
         modelMapper.map(usuario, usuarioModel);
 
-        usuarioModel.add(springLinks.linkToUsuarios("usuarios"));
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            usuarioModel.add(springLinks.linkToUsuarios("usuarios"));
 
-        usuarioModel.add(springLinks.linkToGruposUsuario(usuario.getId(), "grupos-usuario"));
+            usuarioModel.add(springLinks.linkToGruposUsuario(usuario.getId(), "grupos-usuario"));
+        }
 
         return usuarioModel;
     }
 
     @Override
     public CollectionModel<UsuarioModel> toCollectionModel(Iterable<? extends Usuario> entities) {
-        return super.toCollectionModel(entities)
-                .add(springLinks.linkToUsuarios());
+        CollectionModel<UsuarioModel> collectionModel = super.toCollectionModel(entities);
+
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            collectionModel.add(springLinks.linkToUsuarios());
+        }
+
+        return collectionModel;
     }
 
 }

--- a/src/main/java/com/course/springfood/api/v1/controller/GrupoPermissaoController.java
+++ b/src/main/java/com/course/springfood/api/v1/controller/GrupoPermissaoController.java
@@ -5,6 +5,7 @@ import com.course.springfood.api.v1.assembler.PermissaoModelAssembler;
 import com.course.springfood.api.v1.model.PermissaoModel;
 import com.course.springfood.api.v1.openapi.controller.GrupoPermissaoControllerOpenApi;
 import com.course.springfood.core.security.CheckSecurity;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Grupo;
 import com.course.springfood.domain.service.CadastroGrupoService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class GrupoPermissaoController implements GrupoPermissaoControllerOpenApi
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @CheckSecurity.UsuariosGruposPermissoes.PodeConsultar
     @Override
     @GetMapping
@@ -36,14 +40,18 @@ public class GrupoPermissaoController implements GrupoPermissaoControllerOpenApi
 
         CollectionModel<PermissaoModel> permissoesModel
                 = permissaoModelAssembler.toCollectionModel(grupo.getPermissoes())
-                .removeLinks()
-                .add(springLinks.linkToGrupoPermissoes(grupoId))
-                .add(springLinks.linkToGrupoPermissaoAssociacao(grupoId, "associar"));
+                .removeLinks();
 
-        permissoesModel.getContent().forEach(permissaoModel -> {
-            permissaoModel.add(springLinks.linkToGrupoPermissaoDesassociacao(
-                    grupoId, permissaoModel.getId(), "desassociar"));
-        });
+        permissoesModel.add(springLinks.linkToGrupoPermissoes(grupoId));
+
+        if (springSecurity.podeEditarUsuariosGruposPermissoes()) {
+            permissoesModel.add(springLinks.linkToGrupoPermissaoAssociacao(grupoId, "associar"));
+
+            permissoesModel.getContent().forEach(permissaoModel -> {
+                permissaoModel.add(springLinks.linkToGrupoPermissaoDesassociacao(
+                        grupoId, permissaoModel.getId(), "desassociar"));
+            });
+        }
 
         return permissoesModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/controller/RestauranteFormaPagamentoController.java
+++ b/src/main/java/com/course/springfood/api/v1/controller/RestauranteFormaPagamentoController.java
@@ -5,6 +5,7 @@ import com.course.springfood.api.v1.assembler.FormaPagamentoModelAssembler;
 import com.course.springfood.api.v1.model.FormaPagamentoModel;
 import com.course.springfood.api.v1.openapi.controller.RestauranteFormaPagamentoControllerOpenApi;
 import com.course.springfood.core.security.CheckSecurity;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Restaurante;
 import com.course.springfood.domain.service.CadastroRestauranteService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class RestauranteFormaPagamentoController implements RestauranteFormaPaga
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @CheckSecurity.Restaurantes.PodeConsultar
     @Override
     @GetMapping
@@ -36,14 +40,18 @@ public class RestauranteFormaPagamentoController implements RestauranteFormaPaga
 
         CollectionModel<FormaPagamentoModel> formasPagamentoModel
                 = formaPagamentoModelAssembler.toCollectionModel(restaurante.getFormasPagamento())
-                .removeLinks()
-                .add(springLinks.linkToRestauranteFormasPagamento(restauranteId))
-                .add(springLinks.linkToRestauranteFormaPagamentoAssociacao(restauranteId, "associar"));
+                .removeLinks();
 
-        formasPagamentoModel.getContent().forEach(formaPagamentoModel -> {
-            formaPagamentoModel.add(springLinks.linkToRestauranteFormaPagamentoDesassociacao(
-                    restauranteId, formaPagamentoModel.getId(), "desassociar"));
-        });
+        formasPagamentoModel.add(springLinks.linkToRestauranteFormasPagamento(restauranteId));
+
+        if (springSecurity.podeGerenciarFuncionamentoRestaurantes(restauranteId)) {
+            formasPagamentoModel.add(springLinks.linkToRestauranteFormaPagamentoAssociacao(restauranteId, "associar"));
+
+            formasPagamentoModel.getContent().forEach(formaPagamentoModel -> {
+                formaPagamentoModel.add(springLinks.linkToRestauranteFormaPagamentoDesassociacao(
+                        restauranteId, formaPagamentoModel.getId(), "desassociar"));
+            });
+        }
 
         return formasPagamentoModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/controller/RestauranteUsuarioResponsavelController.java
+++ b/src/main/java/com/course/springfood/api/v1/controller/RestauranteUsuarioResponsavelController.java
@@ -5,6 +5,7 @@ import com.course.springfood.api.v1.assembler.UsuarioModelAssembler;
 import com.course.springfood.api.v1.model.UsuarioModel;
 import com.course.springfood.api.v1.openapi.controller.RestauranteUsuarioResponsavelControllerOpenApi;
 import com.course.springfood.core.security.CheckSecurity;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Restaurante;
 import com.course.springfood.domain.service.CadastroRestauranteService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class RestauranteUsuarioResponsavelController implements RestauranteUsuar
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @CheckSecurity.Restaurantes.PodeGerenciarCadastro
     @Override
     @GetMapping
@@ -36,14 +40,18 @@ public class RestauranteUsuarioResponsavelController implements RestauranteUsuar
 
         CollectionModel<UsuarioModel> usuariosModel = usuarioModelAssembler
                 .toCollectionModel(restaurante.getResponsaveis())
-                .removeLinks()
-                .add(springLinks.linkToRestauranteResponsaveis(restauranteId))
-                .add(springLinks.linkToRestauranteResponsavelAssociacao(restauranteId, "associar"));
+                .removeLinks();
 
-        usuariosModel.getContent().stream().forEach(usuarioModel -> {
-            usuarioModel.add(springLinks.linkToRestauranteResponsavelDesassociacao(
-                    restauranteId, usuarioModel.getId(), "desassociar"));
-        });
+        usuariosModel.add(springLinks.linkToRestauranteResponsaveis(restauranteId));
+
+        if (springSecurity.podeGerenciarCadastroRestaurantes()) {
+            usuariosModel.add(springLinks.linkToRestauranteResponsavelAssociacao(restauranteId, "associar"));
+
+            usuariosModel.getContent().stream().forEach(usuarioModel -> {
+                usuarioModel.add(springLinks.linkToRestauranteResponsavelDesassociacao(
+                        restauranteId, usuarioModel.getId(), "desassociar"));
+            });
+        }
 
         return usuariosModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/controller/RootEntryPointController.java
+++ b/src/main/java/com/course/springfood/api/v1/controller/RootEntryPointController.java
@@ -1,6 +1,7 @@
 package com.course.springfood.api.v1.controller;
 
 import com.course.springfood.api.v1.SpringLinks;
+import com.course.springfood.core.security.SpringSecurity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.http.MediaType;
@@ -11,26 +12,52 @@ import springfox.documentation.annotations.ApiIgnore;
 
 @ApiIgnore
 @RestController
-@RequestMapping(path = "/v1/", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(path = "/v1", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RootEntryPointController {
 
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @GetMapping
     public RootEntryPointModel root() {
         var rootEntryPointModel = new RootEntryPointModel();
 
-        rootEntryPointModel.add(springLinks.linkToCozinhas("cozinhas"));
-        rootEntryPointModel.add(springLinks.linkToPedidos("pedidos"));
-        rootEntryPointModel.add(springLinks.linkToRestaurantes("restaurantes"));
-        rootEntryPointModel.add(springLinks.linkToGrupos("grupos"));
-        rootEntryPointModel.add(springLinks.linkToUsuarios("usuarios"));
-        rootEntryPointModel.add(springLinks.linkToPermissoes("permissoes"));
-        rootEntryPointModel.add(springLinks.linkToFormasPagamento("formas-pagamento"));
-        rootEntryPointModel.add(springLinks.linkToEstados("estados"));
-        rootEntryPointModel.add(springLinks.linkToCidades("cidades"));
-        rootEntryPointModel.add(springLinks.linkToEstatisticas("estatisticas"));
+        if (springSecurity.podeConsultarCozinhas()) {
+            rootEntryPointModel.add(springLinks.linkToCozinhas("cozinhas"));
+        }
+
+        if (springSecurity.podePesquisarPedidos()) {
+            rootEntryPointModel.add(springLinks.linkToPedidos("pedidos"));
+        }
+
+        if (springSecurity.podeConsultarRestaurantes()) {
+            rootEntryPointModel.add(springLinks.linkToRestaurantes("restaurantes"));
+        }
+
+        if (springSecurity.podeConsultarUsuariosGruposPermissoes()) {
+            rootEntryPointModel.add(springLinks.linkToGrupos("grupos"));
+            rootEntryPointModel.add(springLinks.linkToUsuarios("usuarios"));
+            rootEntryPointModel.add(springLinks.linkToPermissoes("permissoes"));
+        }
+
+        if (springSecurity.podeConsultarFormasPagamento()) {
+            rootEntryPointModel.add(springLinks.linkToFormasPagamento("formas-pagamento"));
+        }
+
+        if (springSecurity.podeConsultarEstados()) {
+            rootEntryPointModel.add(springLinks.linkToEstados("estados"));
+        }
+
+        if (springSecurity.podeConsultarCidades()) {
+            rootEntryPointModel.add(springLinks.linkToCidades("cidades"));
+        }
+
+        if (springSecurity.podeConsultarEstatisticas()) {
+            rootEntryPointModel.add(springLinks.linkToEstatisticas("estatisticas"));
+        }
 
         return rootEntryPointModel;
     }

--- a/src/main/java/com/course/springfood/api/v1/controller/UsuarioGrupoController.java
+++ b/src/main/java/com/course/springfood/api/v1/controller/UsuarioGrupoController.java
@@ -5,6 +5,7 @@ import com.course.springfood.api.v1.assembler.GrupoModelAssembler;
 import com.course.springfood.api.v1.model.GrupoModel;
 import com.course.springfood.api.v1.openapi.controller.UsuarioGrupoControllerOpenApi;
 import com.course.springfood.core.security.CheckSecurity;
+import com.course.springfood.core.security.SpringSecurity;
 import com.course.springfood.domain.model.Usuario;
 import com.course.springfood.domain.service.CadastroUsuarioService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,9 @@ public class UsuarioGrupoController implements UsuarioGrupoControllerOpenApi {
     @Autowired
     private SpringLinks springLinks;
 
+    @Autowired
+    private SpringSecurity springSecurity;
+
     @CheckSecurity.UsuariosGruposPermissoes.PodeConsultar
     @Override
     @GetMapping
@@ -35,13 +39,16 @@ public class UsuarioGrupoController implements UsuarioGrupoControllerOpenApi {
         Usuario usuario = cadastroUsuario.buscarOuFalhar(usuarioId);
 
         CollectionModel<GrupoModel> gruposModel = grupoModelAssembler.toCollectionModel(usuario.getGrupos())
-                .removeLinks()
-                .add(springLinks.linkToUsuarioGrupoAssociacao(usuarioId, "associar"));
+                .removeLinks();
 
-        gruposModel.getContent().forEach(grupoModel -> {
-            grupoModel.add(springLinks.linkToUsuarioGrupoDesassociacao(
-                    usuarioId, grupoModel.getId(), "desassociar"));
-        });
+        if (springSecurity.podeEditarUsuariosGruposPermissoes()) {
+            gruposModel.add(springLinks.linkToUsuarioGrupoAssociacao(usuarioId, "associar"));
+
+            gruposModel.getContent().forEach(grupoModel -> {
+                grupoModel.add(springLinks.linkToUsuarioGrupoDesassociacao(
+                        usuarioId, grupoModel.getId(), "desassociar"));
+            });
+        }
 
         return gruposModel;
     }

--- a/src/main/java/com/course/springfood/core/security/CheckSecurity.java
+++ b/src/main/java/com/course/springfood/core/security/CheckSecurity.java
@@ -1,13 +1,13 @@
 package com.course.springfood.core.security;
 
-import org.springframework.security.access.prepost.PostAuthorize;
-import org.springframework.security.access.prepost.PreAuthorize;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 public @interface CheckSecurity {
 
@@ -18,7 +18,7 @@ public @interface CheckSecurity {
         @Target(METHOD)
         public @interface PodeEditar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
+        @PreAuthorize("@springSecurity.podeConsultarCozinhas()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -27,19 +27,17 @@ public @interface CheckSecurity {
 
     public @interface Restaurantes {
 
-        @PreAuthorize("hasAuthority('SCOPE_WRITE') and hasAuthority('EDITAR_RESTAURANTES')")
+        @PreAuthorize("@springSecurity.podeGerenciarCadastroRestaurantes()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeGerenciarCadastro { }
 
-        @PreAuthorize("hasAuthority('SCOPE_WRITE') and "
-                + "(hasAuthority('EDITAR_RESTAURANTES') or "
-                + "@springSecurity.gerenciaRestaurante(#restauranteId))")
+        @PreAuthorize("@springSecurity.podeGerenciarFuncionamentoRestaurantes(#restauranteId)")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeGerenciarFuncionamento { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
+        @PreAuthorize("@springSecurity.podeConsultarRestaurantes()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -50,15 +48,13 @@ public @interface CheckSecurity {
 
         @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
         @PostAuthorize("hasAuthority('CONSULTAR_PEDIDOS') or "
-                + "@springSecurity.getUsuarioId() == returnObject.cliente.id or "
+                + "@springSecurity.usuarioAutenticadoIgual(returnObject.cliente.id) or "
                 + "@springSecurity.gerenciaRestaurante(returnObject.restaurante.id)")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeBuscar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and (hasAuthority('CONSULTAR_PEDIDOS') or "
-                + "@springSecurity.getUsuarioId() == #filtro.clienteId or"
-                + "@springSecurity.gerenciaRestaurante(#filtro.restauranteId))")
+        @PreAuthorize("@springSecurity.podePesquisarPedidos(#filtro.clienteId, #filtro.restauranteId)")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodePesquisar { }
@@ -68,8 +64,7 @@ public @interface CheckSecurity {
         @Target(METHOD)
         public @interface PodeCriar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_WRITE') and (hasAuthority('GERENCIAR_PEDIDOS') or "
-                + "@springSecurity.gerenciaRestauranteDoPedido(#codigoPedido))")
+        @PreAuthorize("@springSecurity.podeGerenciarPedidos(#codigoPedido)")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeGerenciarPedidos { }
@@ -83,7 +78,7 @@ public @interface CheckSecurity {
         @Target(METHOD)
         public @interface PodeEditar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
+        @PreAuthorize("@springSecurity.podeConsultarFormasPagamento()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -97,7 +92,7 @@ public @interface CheckSecurity {
         @Target(METHOD)
         public @interface PodeEditar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
+        @PreAuthorize("@springSecurity.podeConsultarCidades()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -111,7 +106,7 @@ public @interface CheckSecurity {
         @Target(METHOD)
         public @interface PodeEditar { }
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and isAuthenticated()")
+        @PreAuthorize("@springSecurity.podeConsultarEstados()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -121,24 +116,24 @@ public @interface CheckSecurity {
     public @interface UsuariosGruposPermissoes {
 
         @PreAuthorize("hasAuthority('SCOPE_WRITE') and "
-                + "@springSecurity.getUsuarioId() == #usuarioId")
+                + "@springSecurity.usuarioAutenticadoIgual(#usuarioId)")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeAlterarPropriaSenha { }
 
         @PreAuthorize("hasAuthority('SCOPE_WRITE') and (hasAuthority('EDITAR_USUARIOS_GRUPOS_PERMISSOES') or "
-                + "@springSecurity.getUsuarioId() == #usuarioId)")
+                + "@springSecurity.usuarioAutenticadoIgual(#usuarioId))")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeAlterarUsuario { }
 
-        @PreAuthorize("hasAuthority('SCOPE_WRITE') and hasAuthority('EDITAR_USUARIOS_GRUPOS_PERMISSOES')")
+        @PreAuthorize("@springSecurity.podeEditarUsuariosGruposPermissoes()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeEditar { }
 
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and hasAuthority('CONSULTAR_USUARIOS_GRUPOS_PERMISSOES')")
+        @PreAuthorize("@springSecurity.podeConsultarUsuariosGruposPermissoes()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }
@@ -147,8 +142,7 @@ public @interface CheckSecurity {
 
     public @interface Estatisticas {
 
-        @PreAuthorize("hasAuthority('SCOPE_READ') and "
-                + "hasAuthority('GERAR_RELATORIOS')")
+        @PreAuthorize("@springSecurity.podeConsultarEstatisticas()")
         @Retention(RUNTIME)
         @Target(METHOD)
         public @interface PodeConsultar { }

--- a/src/main/java/com/course/springfood/core/security/SpringSecurity.java
+++ b/src/main/java/com/course/springfood/core/security/SpringSecurity.java
@@ -21,6 +21,10 @@ public class SpringSecurity {
         return SecurityContextHolder.getContext().getAuthentication();
     }
 
+    public boolean isAutenticado() {
+        return getAuthentication().isAuthenticated();
+    }
+
     public Long getUsuarioId() {
         Jwt jwt = (Jwt) getAuthentication().getPrincipal();
 
@@ -37,6 +41,79 @@ public class SpringSecurity {
 
     public boolean gerenciaRestauranteDoPedido(String codigoPedido) {
         return pedidoRepository.isPedidoGerenciadoPor(codigoPedido, getUsuarioId());
+    }
+
+    public boolean usuarioAutenticadoIgual(Long usuarioId) {
+        return getUsuarioId() != null && usuarioId != null
+                && getUsuarioId().equals(usuarioId);
+    }
+
+    public boolean hasAuthority(String authorityName) {
+        return getAuthentication().getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals(authorityName));
+    }
+
+    public boolean temEscopoEscrita() {
+        return hasAuthority("SCOPE_WRITE");
+    }
+
+    public boolean temEscopoLeitura() {
+        return hasAuthority("SCOPE_READ");
+    }
+
+    public boolean podeGerenciarPedidos(String codigoPedido) {
+        return temEscopoEscrita() && (hasAuthority("GERENCIAR_PEDIDOS")
+                || gerenciaRestauranteDoPedido(codigoPedido));
+    }
+
+    public boolean podeConsultarRestaurantes() {
+        return temEscopoLeitura() && isAutenticado();
+    }
+
+    public boolean podeGerenciarCadastroRestaurantes() {
+        return temEscopoEscrita() && hasAuthority("EDITAR_RESTAURANTES");
+    }
+
+    public boolean podeGerenciarFuncionamentoRestaurantes(Long restauranteId) {
+        return temEscopoEscrita() && (hasAuthority("EDITAR_RESTAURANTES")
+                || gerenciaRestaurante(restauranteId));
+    }
+
+    public boolean podeConsultarUsuariosGruposPermissoes() {
+        return temEscopoLeitura() && hasAuthority("CONSULTAR_USUARIOS_GRUPOS_PERMISSOES");
+    }
+
+    public boolean podeEditarUsuariosGruposPermissoes() {
+        return temEscopoEscrita() && hasAuthority("EDITAR_USUARIOS_GRUPOS_PERMISSOES");
+    }
+
+    public boolean podePesquisarPedidos(Long clienteId, Long restauranteId) {
+        return temEscopoLeitura() && (hasAuthority("CONSULTAR_PEDIDOS")
+                || usuarioAutenticadoIgual(clienteId) || gerenciaRestaurante(restauranteId));
+    }
+
+    public boolean podePesquisarPedidos() {
+        return isAutenticado() && temEscopoLeitura();
+    }
+
+    public boolean podeConsultarFormasPagamento() {
+        return isAutenticado() && temEscopoLeitura();
+    }
+
+    public boolean podeConsultarCidades() {
+        return isAutenticado() && temEscopoLeitura();
+    }
+
+    public boolean podeConsultarEstados() {
+        return isAutenticado() && temEscopoLeitura();
+    }
+
+    public boolean podeConsultarCozinhas() {
+        return isAutenticado() && temEscopoLeitura();
+    }
+
+    public boolean podeConsultarEstatisticas() {
+        return temEscopoLeitura() && hasAuthority("GERAR_RELATORIOS");
     }
 
 }

--- a/src/main/resources/db/migration/V014__cria-tabela-oauth-client-details.sql
+++ b/src/main/resources/db/migration/V014__cria-tabela-oauth-client-details.sql
@@ -1,0 +1,15 @@
+create table oauth_client_details (
+  client_id varchar(255),
+  resource_ids varchar(256),
+  client_secret varchar(256),
+  scope varchar(256),
+  authorized_grant_types varchar(256),
+  web_server_redirect_uri varchar(256),
+  authorities varchar(256),
+  access_token_validity integer,
+  refresh_token_validity integer,
+  additional_information varchar(4096),
+  autoapprove varchar(256),
+
+  primary key (client_id)
+) engine=innodb default charset=utf8;

--- a/src/main/resources/db/testdata/afterMigrate.sql
+++ b/src/main/resources/db/testdata/afterMigrate.sql
@@ -16,6 +16,7 @@ delete from usuario_grupo;
 delete from pedido;
 delete from item_pedido;
 delete from foto_produto;
+delete from oauth_client_details;
 
 set foreign_key_checks = 1;
 
@@ -131,3 +132,26 @@ values (5, '331ed7fe-4a8b-11ec-81d3-0242ac130003', 1, 3, 2, 1, '15800-000', 'Rua
 
 insert into item_pedido (id, pedido_id, produto_id, quantidade, preco_unitario, preco_total, observacao)
 values (6, 5, 3, 1, 90.5, 90.5, null);
+
+
+
+insert into oauth_client_details (
+  client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity, autoapprove
+)
+values (
+  'springfood-web', null, '$2y$12$w3igMjsfS5XoAYuowoH3C.54vRFWlcXSHLjX7MwF990Kc2KKKh72e', 'READ,WRITE', 'password', null, null, 60 * 60 * 6, 60 * 24 * 60 * 60, null
+);
+
+insert into oauth_client_details (
+  client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity, autoapprove
+)
+values (
+  'foodanalytics', null, '$2y$12$fahbH37S2pyk1RPuIHKP.earzFmgAJJGo26rE.59vf4wwiiTKHnzO', 'READ,WRITE', 'authorization_code', 'http://localhost:8082', null, null, null, null
+);
+
+insert into oauth_client_details (
+  client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity, autoapprove
+)
+values (
+  'faturamento', null, '$2y$12$fHixriC7yXX/i1/CmpnGH.RFyK/l5YapLCFOEbIktONjE8ZDykSnu', 'READ,WRITE', 'client_credentials', null, 'CONSULTAR_PEDIDOS,GERAR_RELATORIOS', null, null, null
+);


### PR DESCRIPTION
- **Cadastrando clientes OAuth2 no banco de dados**
Alterando dados de login dos clientes OAuth2 de hard coded (projeto springfood-auth) para banco de dados

- **Gerando links do HAL dinamicamente de acordo com permissões** 
Exibindo os links de retorno "hateoas" de acordo com as permissões do usuário de acesso. 
Obs: não faz sentido exibir um link de aprovar pedido ao usuário que não tem a permissão de alterar pedidos)

- **Bug: Corrigindo lógica de restrição de acessos para Client Credentials Flow**
Obs: Quando um token é gerado por essa Grant, nenhum usuário final é autenticado (não existe um usuário pois utiliza somente a autenticação do Client) e com isso quando ocorre a verificação da anotação de permissão (Anotação "PodePesquisar", ex: "@springSecurity.getUsuarioId() == #filtro.clienteId") e por exemplo um método de listar todos registros é executado (ou seja, o filtro clientId é nulo) a condicação é validada ocasionando uma falha de segurança).