### PR TITLE
Load Balancer - Proxy reverso com Nginx

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,9 +19,17 @@ services:
     command: ["/wait-for-it.sh", "springfood-mysql:3307", "-t", "30", "--", "java", "-jar", "api.jar"]
     environment:
       DB_HOST: springfood-mysql
-    ports:
-      - "8080:8080"
     networks:
       - springfood-network
     depends_on:
       - springfood-mysql
+
+  springfood-proxy:
+    build: ./nginx
+    image: springfood-proxy
+    ports:
+      - "80:80"
+    networks:
+      - springfood-network
+    depends_on:
+      - springfood-api

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.19.6-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,5 @@
+server {
+	location / {
+		proxy_pass http://springfood-api:8080;
+	}
+}

--- a/src/main/java/com/course/springfood/api/HostCheckController.java
+++ b/src/main/java/com/course/springfood/api/HostCheckController.java
@@ -1,0 +1,17 @@
+package com.course.springfood.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+@RestController
+public class HostCheckController {
+
+    @GetMapping("/hostcheck")
+    public String checkHost() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostAddress()
+                + " - " + InetAddress.getLocalHost().getHostName();
+    }
+}

--- a/src/main/resources/db/testdata/afterMigrate.sql
+++ b/src/main/resources/db/testdata/afterMigrate.sql
@@ -1,5 +1,11 @@
 set foreign_key_checks = 0;
 
+lock tables cidade write, cozinha write, estado write, forma_pagamento write,
+	grupo write, grupo_permissao write, permissao write,
+	produto write, restaurante write, restaurante_forma_pagamento write,
+	restaurante_usuario_responsavel write, usuario write, usuario_grupo write,
+	pedido write, item_pedido write, foto_produto write, oauth_client_details write;
+
 delete from cidade;
 delete from cozinha;
 delete from estado;
@@ -155,3 +161,5 @@ insert into oauth_client_details (
 values (
   'faturamento', null, '$2y$12$fHixriC7yXX/i1/CmpnGH.RFyK/l5YapLCFOEbIktONjE8ZDykSnu', 'READ,WRITE', 'client_credentials', null, 'CONSULTAR_PEDIDOS,GERAR_RELATORIOS', null, null, null
 );
+
+unlock tables;


### PR DESCRIPTION
- Ajustando o arquivo afterMigrate para que quando for executar não ocorra concorrência com outro container
- Escalando um serviço com Docker Compose
- Poor Man's Load Balancer (DNS Round Robin)
- Configurando um proxy reverso com Nginx


Obs: Para realizar as requisições agora é necessário especificar a porta 80 (ou não informar nenhuma pois 80 é a porta padrão http). 
Ex: "http://localhost/hostcheck".