### PR TITLE
Configurando Spring Session Data Redis

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,11 +14,18 @@ services:
     networks:
       - springfood-network
 
+  springfood-redis:
+    image: redis:6.2.1-alpine
+    networks:
+      - springfood-network
+
   springfood-api:
     image: springfood-api
     command: ["/wait-for-it.sh", "springfood-mysql:3307", "-t", "30", "--", "java", "-jar", "api.jar"]
     environment:
       DB_HOST: springfood-mysql
+      SPRING_SESSION_STORE_TYPE: redis
+      SPRING_REDIS_HOST: springfood-redis
     networks:
       - springfood-network
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<guava.version>31.0.1-jre</guava.version>
 		<springfox.version>3.0.0</springfox.version>
 		<logback-ext-loggly.version>0.1.5</logback-ext-loggly.version>
-		<spring-security-oauth2.version>2.3.7.RELEASE</spring-security-oauth2.version>
+		<spring-security-oauth2.version>2.3.8.RELEASE</spring-security-oauth2.version>
 		<spring-security-jwt.version>1.0.11.RELEASE</spring-security-jwt.version>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 	</properties>
@@ -204,6 +204,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+
+		<!-- ========== Spring Session Data Redis ========== -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-data-redis</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/course/springfood/core/security/CorsConfig.java
+++ b/src/main/java/com/course/springfood/core/security/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
     public FilterRegistrationBean<CorsFilter> corsFilterRegistrationBean() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(Collections.singletonList("*"));
+        config.setAllowedOriginPatterns(Collections.singletonList("*"));
         config.setAllowedMethods(Collections.singletonList("*"));
         config.setAllowedHeaders(Collections.singletonList("*"));
 

--- a/src/main/java/com/course/springfood/core/security/authorizationserver/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/core/security/authorizationserver/AuthorizationServerConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.provider.CompositeTokenGranter;
 import org.springframework.security.oauth2.provider.TokenGranter;
 import org.springframework.security.oauth2.provider.approval.ApprovalStore;
 import org.springframework.security.oauth2.provider.approval.TokenApprovalStore;
+import org.springframework.security.oauth2.provider.code.JdbcAuthorizationCodeServices;
 import org.springframework.security.oauth2.provider.token.TokenEnhancerChain;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
@@ -66,6 +67,7 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
         endpoints
                 .authenticationManager(authenticationManager)
                 .userDetailsService(userDetailsService)
+                .authorizationCodeServices(new JdbcAuthorizationCodeServices(this.dataSource))
                 .reuseRefreshTokens(false)
                 .accessTokenConverter(jwtAccessTokenConverter())
                 .tokenEnhancer(enhancerChain)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.flyway.locations=classpath:db/migration,classpath:db/testdata
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
 
+spring.session.store-type=none
+
 spring.jackson.deserialization.fail-on-unknown-properties=true
 spring.jackson.deserialization.fail-on-ignored-properties=true
 

--- a/src/main/resources/db/migration/V015__cria-tabela-oauth-code.sql
+++ b/src/main/resources/db/migration/V015__cria-tabela-oauth-code.sql
@@ -1,0 +1,4 @@
+create table oauth_code (
+	code varchar(256),
+	authentication blob
+);


### PR DESCRIPTION
- **Adicionando um container do Redis no arquivo do Docker Compose**

- **Implementando o Spring Session Data Redis**

- **Corrigido problema da HTTP Session no Authorization Server quando utilizado o fluxo Authorization Code**
Obs: A session por padrão é carregada na memória do servidor. Como a aplicação está sendo escalada para mais containers, quando a página de login é acessada a requisição vai para um container e quando digita a senha ela pode ser enviada para o outro container. Com isso, como a memória não é compartilhada um erro é ocasionado. Para resolver isso, foi adotado o uso do Redis, implementando a session do Authorization Server com uma memória compartilhada entre os containers.